### PR TITLE
Add expireAfterSeconds index

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,18 @@ npm i aedes aedes-persistence-mongodb --save
 ### aedesPersistenceMongoDB([opts])
 
 Creates a new instance of aedes-persistence-mongodb.
-It accepts a connections string url or you can pass your existing db object.
+It accepts a connections string url or you can pass your existing db object. Also, you can choose to set a ttl (time to live) for your subscribers or packets. This option will help you to empty your db from keeping useless data.
 
 Example:
 
 ```js
 aedesPersistenceMongoDB({
-  url: 'mongodb://127.0.0.1/aedes-test' //optional when you pass db object
+  url: 'mongodb://127.0.0.1/aedes-test', // Optional when you pass db object
+  // Optional ttl settings
+  ttl: {
+      packets: 300, // Number of seconds
+      subscriptions: 300,
+  }
 })
 ```
 Or

--- a/persistence.js
+++ b/persistence.js
@@ -14,7 +14,6 @@ var qlobberOpts = {
   wildcard_one: '+',
   wildcard_some: '#'
 }
-const EXPIRY_SECONDS = 86400
 
 function MongoPersistence (opts) {
   if (!(this instanceof MongoPersistence)) {
@@ -83,11 +82,16 @@ MongoPersistence.prototype._setup = function () {
       incoming: incoming
     }
 
-    subscriptions.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.subscriptions || EXPIRY_SECONDS) })
-    retained.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS) })
-    will.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS) })
-    outgoing.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS) })
-    incoming.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS) })
+    if (that._opts.ttl.subscriptions) {
+      subscriptions.createIndex({ 'added': 1 }, { expireAfterSeconds: that._opts.ttl.subscriptions })
+    }
+
+    if (that._opts.ttl.packets) {
+      retained.createIndex({ 'added': 1 }, { expireAfterSeconds: that._opts.ttl.packets })
+      will.createIndex({ 'added': 1 }, { expireAfterSeconds: that._opts.ttl.packets })
+      outgoing.createIndex({ 'added': 1 }, { expireAfterSeconds: that._opts.ttl.packets })
+      incoming.createIndex({ 'added': 1 }, { expireAfterSeconds: that._opts.ttl.packets })
+    }
 
     subscriptions.find({
       qos: { $gte: 0 }

--- a/persistence.js
+++ b/persistence.js
@@ -83,11 +83,11 @@ MongoPersistence.prototype._setup = function () {
       incoming: incoming
     }
 
-    subscriptions.createIndex({'added': 1}, {expireAfterSeconds: (that._opts.ttl.subscriptions || EXPIRY_SECONDS)})
-    retained.createIndex({'added': 1}, {expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS)})
-    will.createIndex({'added': 1}, {expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS)})
-    outgoing.createIndex({'added': 1}, {expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS)})
-    incoming.createIndex({'added': 1}, {expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS)})
+    subscriptions.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.subscriptions || EXPIRY_SECONDS) })
+    retained.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS) })
+    will.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS) })
+    outgoing.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS) })
+    incoming.createIndex({ 'added': 1 }, { expireAfterSeconds: (that._opts.ttl.packets || EXPIRY_SECONDS) })
 
     subscriptions.find({
       qos: { $gte: 0 }

--- a/test.js
+++ b/test.js
@@ -361,6 +361,10 @@ function runTest (client, db) {
     clean(db, cleanopts, function (err) {
       t.error(err)
 
+      dbopts.ttl = {
+        packets: 1,
+        subscriptions: 1
+      }
       var emitter = mqemitterMongo(dbopts)
 
       emitter.status.on('stream', function () {
@@ -389,6 +393,10 @@ function runTest (client, db) {
     clean(db, cleanopts, function (err) {
       t.error(err)
 
+      dbopts.ttl = {
+        packets: 1,
+        subscriptions: 1
+      }
       var emitter = mqemitterMongo(dbopts)
 
       emitter.status.on('stream', function () {
@@ -413,13 +421,62 @@ function runTest (client, db) {
           instance.storeRetained(packet, function (err) {
             t.notOk(err, 'no error')
 
-            db.collection('retained').findOne({ topic: 'hello/world' }, function (err, packet) {
+            db.collection('retained').findOne({ topic: 'hello/world' }, function (err, result) {
               t.notOk(err, 'no error')
-              t.deepEqual(date, packet.added, 'must return the packet')
+              t.deepEqual(date, result.added, 'must return the packet')
 
               instance.destroy(t.pass.bind(t))
               emitter.close(t.end.bind(t))
             })
+          })
+        })
+      })
+    })
+  })
+
+  test('look up for expired packets', function (t) {
+    t.plan(7)
+
+    clean(db, cleanopts, function (err) {
+      t.error(err)
+
+      dbopts.ttl = {
+        packets: 1,
+        subscriptions: 1
+      }
+      var emitter = mqemitterMongo(dbopts)
+
+      emitter.status.on('stream', function () {
+        t.pass('mqemitter ready')
+        var instance = persistence(dbopts)
+        instance.broker = toBroker('2', emitter)
+
+        instance.on('ready', function () {
+          t.pass('instance ready')
+
+          var date = new Date()
+          var packet = {
+            cmd: 'publish',
+            id: instance.broker.id,
+            topic: 'hello/world',
+            payload: Buffer.from('muahah'),
+            qos: 0,
+            retain: true,
+            added: date
+          }
+
+          instance.storeRetained(packet, function (err) {
+            t.notOk(err, 'no error')
+
+            setTimeout(function () {
+              db.collection('retained').findOne({ topic: 'hello/world' }, function (err, result) {
+                t.notOk(err, 'no error')
+                t.equal(null, result, 'must return empty packet')
+
+                instance.destroy(t.pass.bind(t))
+                emitter.close(t.end.bind(t))
+              })
+            }, 60000)
           })
         })
       })

--- a/test.js
+++ b/test.js
@@ -354,4 +354,75 @@ function runTest (client, db) {
       })
     })
   })
+
+  test('look up for expire after seconds index', function (t) {
+    t.plan(6)
+
+    clean(db, cleanopts, function (err) {
+      t.error(err)
+
+      var emitter = mqemitterMongo(dbopts)
+
+      emitter.status.on('stream', function () {
+        t.pass('mqemitter ready')
+        var instance = persistence(dbopts)
+        instance.broker = toBroker('1', emitter)
+
+        instance.on('ready', function () {
+          t.pass('instance ready')
+
+          db.collection('retained').indexInformation({ full: true }, function (err, indexes) {
+            t.notOk(err, 'no error')
+            t.deepEqual({ added: 1 }, indexes[1].key, 'must return the index key')
+
+            instance.destroy(t.pass.bind(t))
+            emitter.close(t.end.bind(t))
+          })
+        })
+      })
+    })
+  })
+
+  test('look up for packet with added property', function (t) {
+    t.plan(7)
+
+    clean(db, cleanopts, function (err) {
+      t.error(err)
+
+      var emitter = mqemitterMongo(dbopts)
+
+      emitter.status.on('stream', function () {
+        t.pass('mqemitter ready')
+        var instance = persistence(dbopts)
+        instance.broker = toBroker('2', emitter)
+
+        instance.on('ready', function () {
+          t.pass('instance ready')
+
+          var date = new Date()
+          var packet = {
+            cmd: 'publish',
+            id: instance.broker.id,
+            topic: 'hello/world',
+            payload: Buffer.from('muahah'),
+            qos: 0,
+            retain: true,
+            added: date
+          }
+
+          instance.storeRetained(packet, function (err) {
+            t.notOk(err, 'no error')
+
+            db.collection('retained').findOne({ topic: 'hello/world' }, function (err, packet) {
+              t.notOk(err, 'no error')
+              t.deepEqual(date, packet.added, 'must return the packet')
+
+              instance.destroy(t.pass.bind(t))
+              emitter.close(t.end.bind(t))
+            })
+          })
+        })
+      })
+    })
+  })
 }

--- a/test.js
+++ b/test.js
@@ -476,7 +476,7 @@ function runTest (client, db) {
                 instance.destroy(t.pass.bind(t))
                 emitter.close(t.end.bind(t))
               })
-            }, 60000)
+            }, 65000)
           })
         })
       })


### PR DESCRIPTION
Add expireAfterSeconds index to _subscriptions_, _retained_, _will_, _outgoing_ and _incoming_ collections.
The new key, **added**, is optional and if you not set ttl.packets or ttl.subscriptions the packets or the subscriptions will not expire. More details here: https://docs.mongodb.com/manual/core/index-ttl/#expiration-of-data

You can use:
```
let aedes = require('aedes')({
    persistence: persistenceMongoDB({
        url: 'mongodb://127.0.0.1:27017/aedes',
        ttl: {
            packets: 300,
            subscriptions: 300,
        }
    })
});
```