### PR TITLE
Fix MongoClient deprecation warning

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -41,7 +41,7 @@ MongoPersistence.prototype._connect = function (cb) {
   var conn = this._opts.url || 'mongodb://127.0.0.1/aedes'
 
   // TODO add options
-  mongodb.MongoClient.connect(conn, { useNewUrlParser: true, useUnifiedTopology: true}, cb)
+  mongodb.MongoClient.connect(conn, { useNewUrlParser: true, useUnifiedTopology: true }, cb)
 }
 
 MongoPersistence.prototype._setup = function () {

--- a/persistence.js
+++ b/persistence.js
@@ -41,7 +41,7 @@ MongoPersistence.prototype._connect = function (cb) {
   var conn = this._opts.url || 'mongodb://127.0.0.1/aedes'
 
   // TODO add options
-  mongodb.MongoClient.connect(conn, { useNewUrlParser: true }, cb)
+  mongodb.MongoClient.connect(conn, { useNewUrlParser: true, useUnifiedTopology: true}, cb)
 }
 
 MongoPersistence.prototype._setup = function () {


### PR DESCRIPTION
This edit fixes this warning
```
(node:8234) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
```