### PR TITLE
Custom ttl options for each collection and fixed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "11"
   - "10"
   - "8"
-  - "6"
 env:
   - MONGODB_VERSION="3.4.6"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: true
 node_js:
-  - "11"
+  - "12"
   - "10"
   - "8"
 env:

--- a/README.md
+++ b/README.md
@@ -30,12 +30,39 @@ aedesPersistenceMongoDB({
   }
 })
 ```
-Or
+
+With the previous configuration all packets will have a ttl of 300 seconds. You can also provide different ttl settings for each collection:
+
+```js
+ttl: {
+      packets: {
+        incoming: 100,
+        outgoing: 100,
+        will: 300,
+        retained: -1
+      }, // Number of seconds
+      subscriptions: 300,
+}
 ```
+
+If you want a specific collection to be **persistent** just set a ttl of `-1`.
+
+If you want to reuse an existing MongoDb instance just set the `db` option:
+
+```js
 aedesPersistenceMongoDB({
  db:db
 })
 ```
+
+With mongoose:
+
+```js
+aedesPersistenceMongoDB({
+ db: mongoose.connection.useDb('myDbName')
+})
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ npm i aedes aedes-persistence-mongodb --save
 Creates a new instance of aedes-persistence-mongodb.
 It accepts a connections string `url` or you can pass your existing `db` object. Also, you can choose to set a `ttl` (time to live) for your subscribers or packets. This option will help you to empty your db from keeping useless data.
 
-Example:
+### Options
+
+- `url`: The MongoDB connection url
+- `ttl`: Used to set a ttl (time to live) to documents stored in collections
+  - `packets`: Could be an integer value that specify the ttl in seconds of all packets collections or an Object that specifies for each collection its ttl in seconds. Packets collections are: `incoming`, `outgoing`, `retained`, `will`.
+  - `susbscriptions`: Set a ttl (in seconds)
+- `db`: Existing MongoDB instance (if no `url` option is specified)
+- `dropExistingIndexes`: Flag used to drop any exsisting index previously created on collections (except default index `_id`)
+
+### Examples
 
 ```js
 aedesPersistenceMongoDB({
@@ -45,7 +54,7 @@ ttl: {
 }
 ```
 
-If you want a specific collection to be **persistent** just set a ttl of `-1`.
+If you want a specific collection to be **persistent** just set a ttl of `-1` or `null` or `undefined`.
 
 If you want to reuse an existing MongoDb instance just set the `db` option:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i aedes aedes-persistence-mongodb --save
 ### aedesPersistenceMongoDB([opts])
 
 Creates a new instance of aedes-persistence-mongodb.
-It accepts a connections string url or you can pass your existing db object. Also, you can choose to set a ttl (time to live) for your subscribers or packets. This option will help you to empty your db from keeping useless data.
+It accepts a connections string `url` or you can pass your existing `db` object. Also, you can choose to set a `ttl` (time to live) for your subscribers or packets. This option will help you to empty your db from keeping useless data.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ With mongoose:
 
 ```js
 aedesPersistenceMongoDB({
- db: mongoose.connection.useDb('myDbName')
+ db: mongoose.connection.useDb('myDbName').db
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "concat-stream": "^2.0.0",
     "faucet": "0.0.1",
     "mongo-clean": "^2.0.0",
-    "mqemitter-mongodb": "^5.0.0",
+    "mqemitter-mongodb": "^6.0.1",
     "pre-commit": "^1.2.2",
     "standard": "^12.0.1",
     "tape": "^4.9.0"
@@ -41,6 +41,7 @@
     "aedes-cached-persistence": "^7.0.0",
     "escape-string-regexp": "^1.0.5",
     "mongodb": "^3.0.11",
+    "native-url": "^0.2.3",
     "pump": "^3.0.0",
     "qlobber": "^3.0.2",
     "through2": "^3.0.0"

--- a/persistence.js
+++ b/persistence.js
@@ -98,7 +98,7 @@ MongoPersistence.prototype._setup = function () {
       }
     }
 
-    if (that._opts.ttl.subscriptions) {
+    if (that._opts.ttl.subscriptions >= 0) {
       subscriptions.createIndex({ added: 1 }, { expireAfterSeconds: that._opts.ttl.subscriptions, name: 'ttl' })
     }
 

--- a/persistence.js
+++ b/persistence.js
@@ -249,22 +249,14 @@ MongoPersistence.prototype.addSubscriptions = function (client, subs, cb) {
       )
     })
 
-  this._addedSubscriptions(client, subs, function (err) {
-    finish(err)
-    bulk.execute(finish)
-  })
+  bulk.execute(finish)
+  this._addedSubscriptions(client, subs, finish)
 
   function finish (err) {
-    if (err && !errored) {
-      errored = true
-      cb(err, client)
-      return
-    } else if (errored) {
-      return
-    }
+    errored = err
     published++
     if (published === 2) {
-      cb(null, client)
+      cb(errored, client)
     }
   }
 }

--- a/persistence.js
+++ b/persistence.js
@@ -41,15 +41,14 @@ function MongoPersistence (opts) {
 
 util.inherits(MongoPersistence, CachedPersistence)
 
-MongoPersistence.prototype._connect = function (cb) {
+MongoPersistence.prototype._connect = async function (cb) {
   if (this._opts.db) {
-    cb(null, this._opts.db)
+    await cb(null, this._opts.db)
     return
   }
 
   var conn = this._opts.url || 'mongodb://127.0.0.1/aedes'
 
-  // TODO add options
   mongodb.MongoClient.connect(conn, { useNewUrlParser: true, useUnifiedTopology: true }, cb)
 }
 

--- a/persistence.js
+++ b/persistence.js
@@ -90,6 +90,7 @@ MongoPersistence.prototype._setup = function () {
       incoming: incoming
     }
 
+    // drop existing indexes
     that._dropIndexes(db, function () {
       if (that._opts.ttl.subscriptions >= 0) {
         subscriptions.createIndex({ added: 1 }, { expireAfterSeconds: that._opts.ttl.subscriptions, name: 'ttl' })

--- a/persistence.js
+++ b/persistence.js
@@ -90,8 +90,7 @@ MongoPersistence.prototype._setup = function () {
       incoming: incoming
     }
 
-    // drop existing indexes (if exists)
-    that._dropIndexes(db, function () {
+    function initCollections () {
       if (that._opts.ttl.subscriptions >= 0) {
         subscriptions.createIndex({ added: 1 }, { expireAfterSeconds: that._opts.ttl.subscriptions, name: 'ttl' })
       }
@@ -123,7 +122,14 @@ MongoPersistence.prototype._setup = function () {
       }).on('error', function (err) {
         that.emit('error', err)
       })
-    })
+    }
+
+    // drop existing indexes (if exists)
+    if (that._opts.dropExistingIndexes) {
+      that._dropIndexes(db, initCollections)
+    } else {
+      initCollections()
+    }
   })
 }
 

--- a/test.js
+++ b/test.js
@@ -434,7 +434,7 @@ function runTest (client, db) {
     })
   })
 
-  test.only('drop existing indexes', function (t) {
+  test('drop existing indexes', function (t) {
     function checkIndexes (shouldExist, cb) {
       db.collections(function (err, collections) {
         t.notOk(err, 'no error')

--- a/test.js
+++ b/test.js
@@ -423,7 +423,7 @@ function runTest (client, db) {
 
             db.collection('retained').findOne({ topic: 'hello/world' }, function (err, result) {
               t.notOk(err, 'no error')
-              t.deepEqual(date, result.added, 'must return the packet')
+              t.equal(date.getTime(), result.added.getTime(), 'must return the packet')
 
               instance.destroy(t.pass.bind(t))
               emitter.close(t.end.bind(t))

--- a/test.js
+++ b/test.js
@@ -9,10 +9,10 @@ var clean = require('mongo-clean')
 var dbname = 'aedes-test'
 var mongourl = 'mongodb://127.0.0.1/' + dbname
 var cleanopts = {
-  action: 'remove'
+  action: 'deleteMany'
 }
 
-MongoClient.connect(mongourl, { useNewUrlParser: true, w: 1 }, function (err, client) {
+MongoClient.connect(mongourl, { useNewUrlParser: true, useUnifiedTopology: true, w: 1 }, function (err, client) {
   if (err) {
     throw err
   }


### PR DESCRIPTION
@mcollina 

### Changes

- **Feat**: option to set custom TTL to each collection: subscriptions, incoming, outgoing, will, retained (keep back compatibility)
- **Feat**: Set ttl to -1 to make a collection persistent (no ttl to docs)
- **Fix**: Remove previous created indexes on connect if `dropExistingIndexes` option is specified
- Added test for `dropExistingIndexes`
- **Fix**: deprecation warning of `url.parse` with `native-url` npm package
- **Fix**: `test.js` mongodb deprecation warnings
- Updated `mqemitter-mongodb` to version 6.0.1
- **Feat** Added `createRetainedStreamCombi` and `outgoingEnqueueCombi` methods
- Dropped nodejs 6 support from `.travis.yml`
- Added nodejs 12 support on `.travis.yml`
- **Docs**: Updated readme with new features