### PR TITLE
fix: Updated to aedes-cached-persistence 8.0.0 and optimized tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ node_js:
   - "10"
   - "8"
 env:
-  - MONGODB_VERSION="4.2.2"
+  - MONGODB_VERSION="3.4.6"
 before_install:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz
   - tar xfz mongodb-linux-x86_64-$MONGODB_VERSION.tgz
   - export PATH=`pwd`/mongodb-linux-x86_64-$MONGODB_VERSION/bin:$PATH
   - mkdir -p data/db
-  - mongod --dbpath=data/db &
+  - mongod --dbpath=data/db --setParameter ttlMonitorSleepSecs=2 &
   - sleep 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "10"
   - "8"
 env:
-  - MONGODB_VERSION="3.4.6"
+  - MONGODB_VERSION="4.2.2"
 before_install:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz
   - tar xfz mongodb-linux-x86_64-$MONGODB_VERSION.tgz

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "mqemitter-mongodb": "^6.0.1",
     "pre-commit": "^1.2.2",
     "standard": "^12.0.1",
-    "tape": "^4.9.0"
+    "tape": "^4.12.1"
   },
   "dependencies": {
     "aedes-cached-persistence": "^8.0.0",
     "escape-string-regexp": "^1.0.5",
-    "mongodb": "^3.0.11",
-    "native-url": "^0.2.3",
+    "mongodb": "^3.4.1",
+    "native-url": "^0.2.4",
     "pump": "^3.0.0",
     "qlobber": "^3.0.2",
     "through2": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tape": "^4.9.0"
   },
   "dependencies": {
-    "aedes-cached-persistence": "^7.0.0",
+    "aedes-cached-persistence": "^8.0.0",
     "escape-string-regexp": "^1.0.5",
     "mongodb": "^3.0.11",
     "native-url": "^0.2.3",

--- a/persistence.js
+++ b/persistence.js
@@ -384,6 +384,8 @@ MongoPersistence.prototype.outgoingEnqueueCombi = function (subs, packet, cb) {
   var newp = new Packet(packet)
   var opts = this._opts
 
+  if (!newp.messageId) delete newp.messageId
+
   function createPacket (sub) {
     return {
       clientId: sub.clientId,

--- a/test.js
+++ b/test.js
@@ -557,7 +557,7 @@ function runTest (client, db) {
           instance.storeRetained(packet, function (err) {
             t.notOk(err, 'no error')
 
-            setTimeout(checkRetained.bind(this), 5000) // https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
+            setTimeout(checkRetained.bind(this), 3000) // https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
           })
         })
       })

--- a/test.js
+++ b/test.js
@@ -513,7 +513,7 @@ function runTest (client, db) {
     })
   })
 
-  test('look up for expired packets', function (t) {
+  test.only('look up for expired packets', function (t) {
     t.plan(8)
 
     clean(db, cleanopts, function (err) {
@@ -557,7 +557,7 @@ function runTest (client, db) {
           instance.storeRetained(packet, function (err) {
             t.notOk(err, 'no error')
 
-            setTimeout(checkRetained.bind(this), 3000) // https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
+            setTimeout(checkRetained.bind(this), 5000) // https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
           })
         })
       })

--- a/test.js
+++ b/test.js
@@ -557,7 +557,7 @@ function runTest (client, db) {
           instance.storeRetained(packet, function (err) {
             t.notOk(err, 'no error')
 
-            setTimeout(checkRetained.bind(this), 3000) // https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
+            setTimeout(checkRetained.bind(this), 5000) // https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
           })
         })
       })

--- a/test.js
+++ b/test.js
@@ -513,7 +513,7 @@ function runTest (client, db) {
     })
   })
 
-  test.only('look up for expired packets', function (t) {
+  test('look up for expired packets', function (t) {
     t.plan(8)
 
     clean(db, cleanopts, function (err) {

--- a/test.js
+++ b/test.js
@@ -19,12 +19,19 @@ MongoClient.connect(mongourl, { useNewUrlParser: true, useUnifiedTopology: true,
 
   var db = client.db(dbname)
 
-  clean(db, cleanopts, function (err, db) {
+  // set ttl task to run every 2 seconds
+  db.executeDbAdminCommand({ setParameter: 1, ttlMonitorSleepSecs: 2 }, function (err) {
     if (err) {
       throw err
     }
 
-    runTest(client, db)
+    clean(db, cleanopts, function (err, db) {
+      if (err) {
+        throw err
+      }
+
+      runTest(client, db)
+    })
   })
 })
 
@@ -546,7 +553,7 @@ function runTest (client, db) {
                 instance.destroy(t.pass.bind(t))
                 emitter.close(t.end.bind(t))
               })
-            }, 65000) // MongoDB background task that removes expired documents runs every 60 seconds: https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
+            }, 3000) // MongoDB background task that removes expired documents runs every 60 seconds: https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
           })
         })
       })


### PR DESCRIPTION
Paired with https://github.com/mcollina/aedes-persistence/pull/35

Test time optimixed by 1' by reducing mongodb ttl backgorund task sleep time (60 default) to 2 seconds, this allows to reduce timeout from 65'' to 3'' in retained packets test